### PR TITLE
yed.desktop: fix icon path

### DIFF
--- a/package_root/tmp/yed.desktop
+++ b/package_root/tmp/yed.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Icon=yed
+Icon=/usr/share/yed/icons/yed.ico
 Exec=yed %f
 StartupNotify=true
 StartupWMClass=B-A-A-B


### PR DESCRIPTION
Without this fix, the icon for the yed desktop file couldn't be retrieved and a blank one would be used instead.